### PR TITLE
Update Formula to Delve 1.1.0

### DIFF
--- a/Formula/delve.rb
+++ b/Formula/delve.rb
@@ -1,9 +1,9 @@
 class Delve < Formula
   desc "Debugger for the Go programming language."
   homepage "https://github.com/derekparker/delve"
-  url "https://github.com/derekparker/delve/archive/v1.0.0.tar.gz"
-  version "1.0.0"
-  sha256 "38117c9db41db23a27a1c2e99be17d7fb73d1653de0751ee1262b460a2b26dc4"
+  url "https://github.com/derekparker/delve/archive/v1.1.0.tar.gz"
+  version "1.1.0"
+  sha256 "de023318accf33ffe7cbb393f5a301551390111db8c0849fe5f4002b6c476583"
 
   head "https://github.com/derekparker/delve.git"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This formula is unsupported, Delve can now be [installed on macOS using go get](https://github.com/derekparker/delve/blob/master/Documentation/installation/osx/install.md) (signing is not needed)**
+
 homebrew-delve
 ===============
 


### PR DESCRIPTION
Also edit README.md to note that this us unsupported and Delve can be
installed with go get.